### PR TITLE
Add !clarify command

### DIFF
--- a/Assets/PointOfOrderModule.cs
+++ b/Assets/PointOfOrderModule.cs
@@ -345,6 +345,11 @@ public class PointOfOrderModule : MonoBehaviour
 
     private IEnumerator ProcessTwitchCommand(string command)
     {
+        if (command.ToLowerInvariant() == "clarify")
+        {
+            yield return null;
+            yield return string.Format("sendtochat Pile: {0}", _pile.JoinString(", "));
+        }
         var m = Regex.Match(command, @"^play ([^\s]+) of ([^\s]+)$");
         if (!m.Success || _state != State.FaceDown)
             yield break;


### PR DESCRIPTION
A new clarify option is added for people with poor internet or poor eyesight while playing Point of Order on Twitch Plays.
This new command returns the variable "_pile" into chat.
The help message has not been changed to reflect this addition - feel free to add its mention.